### PR TITLE
Add --token / -t flag functionality

### DIFF
--- a/src/LLMHandler.ts
+++ b/src/LLMHandler.ts
@@ -26,7 +26,7 @@ export class GroqClient {
     fileExtension: string,
     outputType: string,
     modelName: string | null,
-  ): Promise<string | null> {
+  ): Promise<object | null> {
     const apiCall = await this.groq.chat.completions.create({
       messages: [
         {
@@ -48,6 +48,9 @@ export class GroqClient {
       model: modelName || "llama3-8b-8192",
     });
 
-    return apiCall.choices[0].message.content;
+    const message = apiCall.choices[0].message.content;
+    const usage = apiCall.usage;
+
+    return {message, usage};
   }
 }

--- a/src/LLMHandler.ts
+++ b/src/LLMHandler.ts
@@ -51,6 +51,6 @@ export class GroqClient {
     const message = apiCall.choices[0].message.content;
     const usage = apiCall.usage;
 
-    return {message, usage};
+    return { message, usage };
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,10 @@ program
   .option("-lm,--list_models", "Lists the available models for the Groq API")
   .option("-m,--model <options>", "Give the model for the API to be used")
   .option("-a,--api_key <options>", "Provide the API Key for Groq API")
-  .option("-t,--token", "Lists the prompt tokens, completion tokens, and total tokens consumed from using the Groq API")
+  .option(
+    "-t,--token",
+    "Lists the prompt tokens, completion tokens, and total tokens consumed from using the Groq API",
+  )
 
   .action(async (files: string[], options: string[] | any) => {
     if (options.list_models) {
@@ -102,7 +105,7 @@ please choose from the following options
       }
 
       const showTokenUsage = options.token || false;
-      
+
       let totalPromptTokens = 0;
       let totalCompletionTokens = 0;
       let totalTokens = 0;
@@ -122,10 +125,17 @@ please choose from the following options
             fileContents,
             fileExtension,
             outputLanguage,
-            modelName
-          )) as { message: string, usage: { prompt_tokens: number, completion_tokens: number, total_tokens: number } };
+            modelName,
+          )) as {
+            message: string;
+            usage: {
+              prompt_tokens: number;
+              completion_tokens: number;
+              total_tokens: number;
+            };
+          };
 
-          if (showTokenUsage && usage){
+          if (showTokenUsage && usage) {
             totalPromptTokens += usage.prompt_tokens;
             totalCompletionTokens += usage.completion_tokens;
             totalTokens += usage.total_tokens;
@@ -149,13 +159,16 @@ please choose from the following options
         ),
       );
 
-      if (showTokenUsage){
+      if (showTokenUsage) {
         console.warn(chalk.blueBright("Token Usage Information:"));
-        console.warn(`${chalk.yellowBright('Prompt Tokens:')} ${totalPromptTokens}`);
-        console.warn(`${chalk.yellowBright('Completion Tokens:')} ${totalCompletionTokens}`);
-        console.warn(`${chalk.yellowBright('Total Tokens:')} ${totalTokens}`);
+        console.warn(
+          `${chalk.yellowBright("Prompt Tokens:")} ${totalPromptTokens}`,
+        );
+        console.warn(
+          `${chalk.yellowBright("Completion Tokens:")} ${totalCompletionTokens}`,
+        );
+        console.warn(`${chalk.yellowBright("Total Tokens:")} ${totalTokens}`);
       }
-
     } catch (e) {
       spinner.fail("Failed");
       console.log(chalk.redBright(e));

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ program
   .option("-lm,--list_models", "Lists the available models for the Groq API")
   .option("-m,--model <options>", "Give the model for the API to be used")
   .option("-a,--api_key <options>", "Provide the API Key for Groq API")
+  .option("-t,--token", "Lists the prompt tokens, completion tokens, and total tokens consumed from using the Groq API")
 
   .action(async (files: string[], options: string[] | any) => {
     if (options.list_models) {


### PR DESCRIPTION
This resolves #14, which deals with displaying the `tokens consumed` from making an API request to `groq`.

Now, when the user runs the dialectMorph command (or `bun start` when testing locally), they should see the following:

![token-information](https://github.com/user-attachments/assets/b4cb83cc-3c1c-4549-a05d-9a172b0f569c)

- users can now use `-t` or `--token` to get information regarding the `Prompt Tokens`, `Completion Tokens`, and `Total Tokens` consumed
- existing commands still work

Additionally, the help option has been updated to explain what `-t`/`--token` do:

![dialectMorph-help-is-updated](https://github.com/user-attachments/assets/f1370529-ff51-4ece-9fcb-01dec3c91c9c)

