### PR TITLE
replace rootDir with include in .tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
 		"strict": true,
 		"skipLibCheck": true,
 		"noFallthroughCasesInSwitch": true,
-		"rootDir": "src",
 		"outDir": "dist",
 		"esModuleInterop": true,
 
@@ -24,5 +23,5 @@
 		"noUnusedParameters": false,
 		"noPropertyAccessFromIndexSignature": false
 	},
-	"exclude": ["examples", "node_modules", "dist", "eslint.config.js"]
+	"include": ["src/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
Fixes #29 

I removed `rootDir` and `exclude` and replaced them with `include` which whitelists directories for TypeScript to handle.

Note this means the `build` command will also build the tests, but I'm unaware of a better solution.